### PR TITLE
Fix anonymous1184#44

### DIFF
--- a/Lib/GetStdStream.ahk
+++ b/Lib/GetStdStream.ahk
@@ -10,7 +10,8 @@ GetStdStream(CommandLine, Environment := "")
 	NumPut(104, lpStartupInfo) ; STARTUPINFO size
 	NumPut(0x100, lpStartupInfo, 60) ; dwFlags = STARTF_USESTDHANDLES
 	NumPut(hPipeWrite, lpStartupInfo, 88) ; hStdOutput
-	NumPut(hPipeWrite, lpStartupInfo, 96) ; hStdError
+	; Ignore StdError
+	; NumPut(hPipeWrite, lpStartupInfo, 96) ; hStdError
 
 	lpEnvironment := 0
 	if IsObject(Environment)


### PR DESCRIPTION
The error with `Unexpected character at position 1: 'V'` also showed up on my machine. After debugging it, I discovered that the "V" was from message "Vault is locked." 

This was because after Autotype unlocked the vault, the Bitwarden CLI printed not only the BW_SESSION key, but before that there was "mac failed" message, which resulted in Autotype passing the wrong session to the CLI. I don't know why that message happens, but it looks like it can be safely and easily ignored, since it is outputted to StdErr.

My fix is to not capture StdErr. I am not sure if Autotype ever relies on it, but from my testing, it didn't seem like it broke anything.